### PR TITLE
security vulnerability in requests < 2.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pathlib==1.0.1
 psycopg2==2.7.4
 pytz==2018.3
 whitenoise==3.3.1
-requests==2.18.4
+requests>=2.20,<3
 djangorestframework==3.8.2
 raven>=3


### PR DESCRIPTION
https://github.com/TechEquity-Collaborative/Voter-Info/network/alert/requirements.txt/requests/open


Remediation
Upgrade requests to version 2.20.0 or later. For example:

requests>=2.20.0
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2018-18074 More information
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.